### PR TITLE
Version 0.0.8

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,11 @@
 MIT License
 
 Copyright (c) 2019 pqzx
+Copyright (c) 2023 John Jordan
+
+Copyright for portions of this project committed to the original repository are
+held by pqzx, 2019.  Copyright for portions of this project committed thereafter
+are held by John Jordan, 2023.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
-# htmldocx
-Convert html to docx
+# html3docx
+A fork of https://github.com/pqzx/html2docx.  This version will focus on expedient changes for our particular use case.
 
 Dependencies: `python-docx` & `bs4`
 
 ### To install
 
-`pip install htmldocx`
+`pip install html3docx`
+
+### Improvements
+
+- Fix for KeyError when handling an img tag without a src attribute.
+- Images with a width attribute will be scaled according to that width.
+- Fix for AttributeError when handling a leading br tag, either at the top of the HTML snippet, or within a td or th cell.
+
+## Original README
 
 ### Usage
 

--- a/htmldocx/h2d.py
+++ b/htmldocx/h2d.py
@@ -318,7 +318,7 @@ class HtmlToDocx(HTMLParser):
                         attr_width = None
                     if attr_width is not None:
                         # Get horizontal dpi
-                        dpi = Image.from_blob(image).horz_dpi
+                        dpi = Image.from_blob(image.read()).horz_dpi
                         # Convert pixels to inches
                         img_inch_width = Inches(attr_width / dpi)
                         self.doc.add_picture(image, width=img_inch_width)
@@ -433,7 +433,15 @@ class HtmlToDocx(HTMLParser):
             self.tags['list'].append(tag)
             return # don't apply styles for now
         elif tag == 'br':
-            self.run.add_break()
+            if hasattr(self, 'run'):
+                self.run.add_break()
+            else:
+                # This case happens when the HTML snippet begins with a <br />
+                # Trade-off: This yields an empty paragraph instead of a line break.  But if we were to add a
+                # line break to this paragraph, we would end up with 2 empty lines in the document instead of one.
+                # I think in this case, I would rather have the one empty paragraph than 2 empty lines.
+                self.paragraph = self.doc.add_paragraph()
+                self.run = self.paragraph.add_run()
             return
 
         self.tags[tag] = current_attrs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,12 @@
 [project]
 name = "html3docx"
-version = "0.0.7"
+version = "0.0.8"
 authors = [
   {name="John Jordan"},
 ]
-description = "A fork of https://github.com/pqzx/html2docx.  This version will focus on expedient changes for my particular use case.  I may contribute ideas back to the main version, but it sees to be mostly dead."
+description = "A fork of https://github.com/pqzx/html2docx.  This version will focus on expedient changes for our particular use case."
+readme = "README.md"
+license = {file = "LICENSE"}
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/tests/test.py
+++ b/tests/test.py
@@ -239,6 +239,24 @@ and blank lines.
         )
         self.parser.add_html_to_document("<img />", self.document)
 
+    def test_br_in_table(self):
+        # A <br /> in a <table>, but not in a <td>, is illegal.
+        self.document.add_heading(
+            'Test: Handling BR in TABLE',
+            level=1
+        )
+        self.parser.add_html_to_document(
+            "<table><tr>"
+            "<td><p>Hello</p></td>"
+            "<td><br /><p>Hello</p></td>"
+            "<td><p>Hello<br />goodbye</p></td>"
+            "</tr></table>",
+            self.document)
+
+    def test_leading_br(self):
+        self.document.add_heading('Test: Leading BR', level=1)
+        self.parser.add_html_to_document("<br /><p>Hello</p>", self.document)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix for AttributeError when handling a leading br tag, either at the top of the HTML snippet, or within a td or th cell.
Fix for TypeError when claling Image.from_blob() to get the image's DPI.