### PR TITLE
Fix a bug that after fetching img  if src is not an url, image variab…

### DIFF
--- a/htmldocx/h2d.py
+++ b/htmldocx/h2d.py
@@ -355,7 +355,8 @@ class HtmlToDocx(HTMLParser):
             except urllib.error.URLError:
                 image = None
         else:
-            image = src
+            with open(src, 'rb') as f:
+                image = io.BytesIO(f.read())
         # add image to doc
         if image:
             try:


### PR DESCRIPTION
Fix a bug that after fetching img  if src is not an url, image variable should be a BytesIO object.