### PR TITLE
Images with base64 encoded data src

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ PyPI: https://pypi.org/project/html3docx/
 - Images with a width attribute will be scaled according to that width.
 - Fix for AttributeError when handling a leading br tag, either at the top of the HTML snippet, or within a td or th cell.
 - Fix for IndexError when a table has more cells in latter rows than in the first row.
+- Ordered lists will now restart at 1. when proceeded by a paragraph that is not a numbered list.
 - Parameterized image fetcher function.
+- Parameterized default styles for OL, UL, and TABLE tags.
 - Fix for KeyError when handling an anchor with no href attribute.
+- Added support for images with base64 encoded data src.
 
 ## Original README
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "html3docx"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
   {name="John Jordan"},
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-beautifulsoup4==4.8.0
-python-docx==0.8.10
+beautifulsoup4>=4.8.0,<5
+python-docx>=0.8.10


### PR DESCRIPTION
- Added support for images with base64 encoded data as the src. (i.e. src="data:etc").
- Changed requirements.txt to use >= instead of ==.

I didn't add handling for images with data URLs that are not base64 encoded, nor handling for other tags with data URLs because I have never encountered one of these in the wild and I'm not sure what the use case is.  I may try it later.

I used this document as a reference: https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data